### PR TITLE
feat: added broker prototype

### DIFF
--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -1,0 +1,111 @@
+package broker
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestNewSupervisor(t *testing.T) {
+	supervisor := NewSupervisor()
+	if supervisor.clientsMapping == nil {
+		t.Fatalf("error, expected clientsMapping to be a nil pointer, instead got %v", supervisor.clientsMapping)
+	}
+	if supervisor.clientsMutex == nil {
+		t.Fatalf("error, expected clientsMutex to be a nil pointer, instead got %v", supervisor.clientsMutex)
+	}
+	if supervisor.IsRunning != false {
+		t.Fatalf("error, expected IsRunning to be a false, instead got %v", supervisor.IsRunning)
+	}
+	if supervisor.clientOperationChannel == nil {
+		t.Fatalf("error, expected clientOperationChannel to be a nil pointer, instead got %v", supervisor.clientOperationChannel)
+	}
+	if supervisor.stoppedSignal == nil {
+		t.Fatalf("error, expected stoppedSignal to be a nil pointer, instead got %v", supervisor.stoppedSignal)
+	}
+	if supervisor.startedSignal == nil {
+		t.Fatalf("error, expected startedSignal to be a nil pointer, instead got %v", supervisor.startedSignal)
+	}
+	if supervisor.mainWg == nil {
+		t.Fatalf("error, expected mainWg to be a nil pointer, instead got %v", supervisor.mainWg)
+	}
+	if supervisor.clientCount != 0 {
+		t.Fatalf("error, expected clientCount to be a zero, instead got %v", supervisor.clientCount)
+	}
+}
+
+func TestRun(t *testing.T) {
+	var wg sync.WaitGroup
+	supervisor := NewSupervisor()
+	wg.Add(1)
+	go func() {
+		supervisor.START()
+		wg.Done()
+	}()
+	supervisor.WaitUntilReady()
+	if supervisor.IsRunning != true {
+		t.Fatalf("error, expected IsRunnint to be True, instead got %v", supervisor.IsRunning)
+	}
+	supervisor.STOP()
+	wg.Wait()
+	if supervisor.IsRunning != false {
+		t.Fatalf("error, expected IsRunnint to be False, instead got %v", supervisor.IsRunning)
+	}
+}
+
+func TestAddClient(t *testing.T) {
+	var wg sync.WaitGroup
+	supervisor := NewSupervisor()
+	wg.Add(1)
+	go func() {
+		supervisor.START()
+		wg.Done()
+	}()
+	supervisor.WaitUntilReady()
+	client := Client{
+		Id: "1",
+	}
+	supervisor.SignalClientAddition(&client)
+	supervisor.STOP()
+	wg.Wait()
+	clientCount := supervisor.GetClientCount()
+	if clientCount != 1 {
+		t.Fatalf("error, expected GetClientCount to return 1, instead got %v", clientCount)
+	}
+	result := supervisor.clientsMapping[client.Id]
+	if result == nil {
+		t.Fatalf("error, expected result not to be a poiner")
+	}
+	if *result != client {
+		t.Fatal("error, expected result to point to the same location address ass the defined client")
+	}
+}
+
+func TestRemoveClient(t *testing.T) {
+	var wg sync.WaitGroup
+	supervisor := NewSupervisor()
+	wg.Add(1)
+	go func() {
+		supervisor.START()
+		wg.Done()
+	}()
+	supervisor.WaitUntilReady()
+	client := Client{
+		Id: "1",
+	}
+	_ = supervisor.addClient(&client)
+	clientCount := supervisor.GetClientCount()
+	if clientCount != 1 {
+		t.Fatalf("error, expected GetClientCount to return 1, instead got %v", clientCount)
+	}
+	supervisor.SignalClientRemoval(&client)
+	supervisor.STOP()
+	wg.Wait()
+	clientCount = supervisor.GetClientCount()
+	if clientCount != 0 {
+		t.Fatalf("error, expected GetClientCount to return 0, instead got %v", clientCount)
+	}
+	result := supervisor.clientsMapping[client.Id]
+	if result != nil {
+		t.Fatalf("error, expected result to be a nil pointer, instead got %v", result)
+	}
+}

--- a/broker/client.go
+++ b/broker/client.go
@@ -1,0 +1,5 @@
+package broker
+
+type Client struct {
+	Id string
+}

--- a/broker/clientOperation.go
+++ b/broker/clientOperation.go
@@ -1,0 +1,13 @@
+package broker
+
+type Operation byte
+
+const (
+	Remove Operation = iota
+	Add
+)
+
+type ClientOperation struct {
+	Operation Operation
+	Client    *Client
+}

--- a/broker/supervisor.go
+++ b/broker/supervisor.go
@@ -1,0 +1,98 @@
+package broker
+
+import (
+	"fmt"
+	"sync"
+)
+
+type Supervisor struct {
+	IsRunning              bool
+	clientCount            uint
+	clientsMutex           *sync.Mutex
+	clientsMapping         map[string]*Client
+	clientOperationChannel chan ClientOperation
+	stoppedSignal          chan struct{}
+	startedSignal          chan struct{}
+	mainWg                 *sync.WaitGroup
+}
+
+func NewSupervisor() *Supervisor {
+	return &Supervisor{
+		clientCount:            0,
+		IsRunning:              false,
+		clientsMutex:           &sync.Mutex{},
+		clientsMapping:         make(map[string]*Client),
+		clientOperationChannel: make(chan ClientOperation),
+		stoppedSignal:          make(chan struct{}),
+		startedSignal:          make(chan struct{}),
+		mainWg:                 &sync.WaitGroup{},
+	}
+}
+
+func (s *Supervisor) START() {
+	s.mainWg.Add(1)
+	go s.waitForClientOperations()
+	s.IsRunning = true
+	close(s.startedSignal)
+	s.mainWg.Wait()
+	s.IsRunning = false
+
+}
+
+func (s *Supervisor) waitForClientOperations() {
+	defer s.mainWg.Done()
+	for {
+		select {
+		case o := <-s.clientOperationChannel:
+			switch o.Operation {
+			case Add:
+				s.addClient(o.Client)
+			case Remove:
+				s.removeClient(o.Client.Id)
+			default:
+				fmt.Println("no operation")
+			}
+		case <-s.stoppedSignal:
+			return
+		}
+	}
+
+}
+
+func (s *Supervisor) addClient(c *Client) error {
+	s.clientsMutex.Lock()
+	defer s.clientsMutex.Unlock()
+	s.clientsMapping[c.Id] = c
+	s.clientCount += 1
+	return nil
+}
+
+func (s *Supervisor) removeClient(clientId string) {
+	s.clientsMutex.Lock()
+	defer s.clientsMutex.Unlock()
+	delete(s.clientsMapping, clientId)
+	s.clientCount -= 1
+}
+
+func (s *Supervisor) GetClientCount() uint {
+	s.clientsMutex.Lock()
+	defer s.clientsMutex.Unlock()
+	return s.clientCount
+
+}
+
+func (s *Supervisor) SignalClientAddition(c *Client) {
+	s.clientOperationChannel <- ClientOperation{Add, c}
+}
+
+func (s *Supervisor) SignalClientRemoval(c *Client) {
+	s.clientOperationChannel <- ClientOperation{Remove, c}
+}
+
+func (s *Supervisor) WaitUntilReady() {
+	<-s.startedSignal
+}
+
+func (s *Supervisor) STOP() {
+	close(s.stoppedSignal)
+}


### PR DESCRIPTION
**related issue:** #13
Started adding a package that handles a dictionary of clients. The library exposes a struct with some methods that allows:
* create a new supervisor
* keep track of clients in a map
* add or remove clients asynchronous
* start the process that keeps the supervisor active
* stop the process of this supervisor